### PR TITLE
[MM-13516] Fix rendering of table if markdown has space/s at the end of header/rows

### DIFF
--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -665,12 +665,14 @@ var blockStarts = [
         }
 
         // check for a delimiter first since it's stricter than the header row
-        var delimiterMatch = reTableDelimiter.exec(parser.nextLine);
+        const nextLine = trimSpacesAfterPipe(parser.nextLine);
+        var delimiterMatch = reTableDelimiter.exec(nextLine);
         if (!delimiterMatch || delimiterMatch[0].indexOf('|') === -1) {
             return 0;
         }
 
-        var headerMatch = reTableRow.exec(parser.currentLine.slice(parser.nextNonspace));
+        const currentLine = trimSpacesAfterPipe(parser.currentLine);
+        var headerMatch = reTableRow.exec(currentLine.slice(parser.nextNonspace));
         if (!headerMatch) {
             return 0;
         }
@@ -1028,7 +1030,7 @@ var parse = function(input) {
     this.currentLine = "";
     this.shouldSkipNextLine = false;
     if (this.options.time) { console.time("preparing input"); }
-    var lines = input.split(reLineEnding).map(trimSpacesAfterPipe);
+    var lines = input.split(reLineEnding);
     var len = lines.length;
     if (input.charCodeAt(input.length - 1) === C_NEWLINE) {
         // ignore last blank line created by final newline

--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -62,6 +62,8 @@ var reTableDelimiter = /^[ \t]{0,3}((?:\|[ \t]*)?:?-+:?[ \t]*(?:\|(?:[ \t]*:?-+:
 
 var reTableRow = /^(\|?)(?:(?:\\\||[^|])*\|?)+$/;
 
+var reTablePipeSpaceEnding = /\|\s+$/;
+
 // Returns true if string contains only space characters.
 var isBlank = function(s) {
     return !(reNonSpace.test(s));
@@ -78,6 +80,10 @@ var peek = function(ln, pos) {
         return -1;
     }
 };
+
+var trimSpacesAfterPipe = function(ln) {
+    return ln.replace(reTablePipeSpaceEnding,'|');
+}
 
 // DOC PARSER
 
@@ -1022,7 +1028,7 @@ var parse = function(input) {
     this.currentLine = "";
     this.shouldSkipNextLine = false;
     if (this.options.time) { console.time("preparing input"); }
-    var lines = input.split(reLineEnding);
+    var lines = input.split(reLineEnding).map(trimSpacesAfterPipe);
     var len = lines.length;
     if (input.charCodeAt(input.length - 1) === C_NEWLINE) {
         // ignore last blank line created by final newline

--- a/test/tables.txt
+++ b/test/tables.txt
@@ -1072,3 +1072,96 @@ Here's a link to [Freedom Planet 2][].
 <td></td>
 </tr></tbody></table>
 ````````````````````````````````
+
+### Table without space at the end
+
+```````````````````````````````` example
+| Header 1 | Header 2 |
+| :--: | :--: |
+| r1c1 | r1c2 |
+| r2c1 | r2c2 |
+| r3c1 | r3c2 |
+.
+<table>
+<thead>
+<tr>
+<th align="center">Header 1</th>
+<th align="center">Header 2</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td align="center">r1c1</td>
+<td align="center">r1c2</td>
+</tr>
+<tr>
+<td align="center">r2c1</td>
+<td align="center">r2c2</td>
+</tr>
+<tr>
+<td align="center">r3c1</td>
+<td align="center">r3c2</td>
+</tr></tbody></table>
+````````````````````````````````
+
+### Table with space at the end
+
+```````````````````````````````` example
+| Header 1 | Header 2 | 
+| :--: | :--: | 
+| r1c1 | r1c2 | 
+| r2c1 | r2c2 | 
+| r3c1 | r3c2 | 
+.
+<table>
+<thead>
+<tr>
+<th align="center">Header 1</th>
+<th align="center">Header 2</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td align="center">r1c1</td>
+<td align="center">r1c2</td>
+</tr>
+<tr>
+<td align="center">r2c1</td>
+<td align="center">r2c2</td>
+</tr>
+<tr>
+<td align="center">r3c1</td>
+<td align="center">r3c2</td>
+</tr></tbody></table>
+````````````````````````````````
+
+### Table with multiple spaces at the end
+
+```````````````````````````````` example
+| Header 1 | Header 2 |   
+| :--: | :--: |
+| r1c1 | r1c2 |         
+| r2c1 | r2c2 |    
+| r3c1 | r3c2 | 
+.
+<table>
+<thead>
+<tr>
+<th align="center">Header 1</th>
+<th align="center">Header 2</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td align="center">r1c1</td>
+<td align="center">r1c2</td>
+</tr>
+<tr>
+<td align="center">r2c1</td>
+<td align="center">r2c2</td>
+</tr>
+<tr>
+<td align="center">r3c1</td>
+<td align="center">r3c2</td>
+</tr></tbody></table>
+````````````````````````````````


### PR DESCRIPTION
Fix rendering of table if markdown input has space/s at the end of header/rows
-  by checking each line if it's ending with pipe and space/s.  If yes, then replace with pipe only.
- Added tests for table
- run benchmark and found no performance degradation except slight decrease on commonmark.js (-3%).

Benchmark for Master:
<img width="406" alt="Screen Shot 2019-03-19 at 8 52 05 PM" src="https://user-images.githubusercontent.com/5334504/54607650-d7064c80-4a89-11e9-9160-d2710a1151f2.png">

Benchmark for this PR:
<img width="403" alt="Screen Shot 2019-03-19 at 8 53 40 PM" src="https://user-images.githubusercontent.com/5334504/54607662-e1284b00-4a89-11e9-8ba7-d0cebf2ad62f.png">
