### PR TITLE
[MM-13837] Link ending with curly brace is correctly formatted

### DIFF
--- a/lib/inlines.js
+++ b/lib/inlines.js
@@ -834,7 +834,7 @@ var parseEntity = function(block) {
 };
 
 // Attempt to parse a url
-var reUrl = XRegExp.cache('^(?:[A-Za-z][A-Za-z\\d-.+]*:(?:\\/{1,3}|[\\pL\\d%])|www\\d{0,3}[.]|[\\pL\\d.\\-]+[.]\\pL{2,4}\\/)(?:\\[[\\da-f:]+\\]|[^\\s`!()\\[\\]{;:\'",<>?«»“”‘’*_]|[*_]+(?=[^_*\\s])|[`!\\[\\]{};:\'",<>?«»“”‘’](?=[^\\s()<>])|\\((?:[^\\s()<>]|(?:\\([^\\s()<>]+\\)))*\\))+', 'i');
+var reUrl = XRegExp.cache('^(?:[A-Za-z][A-Za-z\\d-.+]*:(?:\\/{1,3}|[\\pL\\d%])|www\\d{0,3}[.]|[\\pL\\d.\\-]+[.]\\pL{2,4}\\/)(?:\\[[\\da-f:]+\\]|[^\\s`!()\\[\\]{;:\'",<>?«»“”‘’*_]|[*_]+(?=[^_*\\s])|[`!\\[\\]{;:\'",<>?«»“”‘’](?=[^\\s()<>])|\\((?:[^\\s()<>]|(?:\\([^\\s()<>]+\\)))*\\))+', 'i');
 var parseUrl = function(block) {
     if (this.brackets) {
         // Don't perform autolinking while inside an explicit link

--- a/lib/inlines.js
+++ b/lib/inlines.js
@@ -834,7 +834,7 @@ var parseEntity = function(block) {
 };
 
 // Attempt to parse a url
-var reUrl = XRegExp.cache('^(?:[A-Za-z][A-Za-z\\d-.+]*:(?:\\/{1,3}|[\\pL\\d%])|www\\d{0,3}[.]|[\\pL\\d.\\-]+[.]\\pL{2,4}\\/)(?:\\[[\\da-f:]+\\]|[^\\s`!()\\[\\]{};:\'",<>?«»“”‘’*_]|[*_]+(?=[^_*\\s])|[`!\\[\\]{};:\'",<>?«»“”‘’](?=[^\\s()<>])|\\((?:[^\\s()<>]|(?:\\([^\\s()<>]+\\)))*\\))+', 'i');
+var reUrl = XRegExp.cache('^(?:[A-Za-z][A-Za-z\\d-.+]*:(?:\\/{1,3}|[\\pL\\d%])|www\\d{0,3}[.]|[\\pL\\d.\\-]+[.]\\pL{2,4}\\/)(?:\\[[\\da-f:]+\\]|[^\\s`!()\\[\\]{;:\'",<>?«»“”‘’*_]|[*_]+(?=[^_*\\s])|[`!\\[\\]{};:\'",<>?«»“”‘’](?=[^\\s()<>])|\\((?:[^\\s()<>]|(?:\\([^\\s()<>]+\\)))*\\))+', 'i');
 var parseUrl = function(block) {
     if (this.brackets) {
         // Don't perform autolinking while inside an explicit link

--- a/test/mattermost.txt
+++ b/test/mattermost.txt
@@ -7,6 +7,12 @@
 ### URLs starting with a valid protocol (`http:`, `ftp:`, etc) or `www.` are autolinked:
 
 ```````````````````````````````` example
+http://example/result?things={stuff}
+.
+<p><a href="http://example/result?things=%7Bstuff%7D">http://example/result?things={stuff}</a></p>
+````````````````````````````````
+
+```````````````````````````````` example
 http://example.com
 .
 <p><a href="http://example.com">http://example.com</a></p>


### PR DESCRIPTION
**Summary**
Allows curly brace to be at the end of a link without leaving it out. This ticket is regarding commonmark.js which is used on mattermost mobile application.

Ticket Link
[Github Ticket](https://github.com/mattermost/mattermost-server/issues/10774)
[Jira Ticket](https://mattermost.atlassian.net/browse/MM-13837)