### PR TITLE
Adds new node type 'highlight_without_notification'

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ The parser returns a Node.  The following public properties are defined
   `html_block`, `thematic_break`.
     - (**Mattermost**) This fork also adds `at_mention`,
     `channel_link`, `emoji`, `hashtag`, `latex_inline`, 
-    `mention_highlight`, `search_highlight`, `table`, `table_row`,
+    `mention_highlight`, `highlight_without_notification`, `search_highlight`, `table`, `table_row`,
     `table_cell`, `edited_indicator`, `checkbox`.
 - `firstChild` (read-only):  a Node or null.
 - `lastChild` (read-only): a Node or null.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -4,7 +4,7 @@ export type NodeType =
     'text' |'softbreak' | 'linebreak' | 'emph' | 'strong' | 'html_inline' | 'link' | 'image' | 'code' | 'document' | 'paragraph' |
     'block_quote' | 'item' | 'list' | 'heading' | 'code_block' | 'html_block' | 'thematic_break' | 'custom_inline' | 'custom_block' | 
     'at_mention' | 'channel_link' | 'emoji' | 'hashtag' | 'latex_inline' | 'table' | 'table_row' | 'table_cell' | 'mention_highlight' |
-    'search_highlight' | 'checkbox' | 'edited_indicator';
+    'highlight_without_notification' | 'search_highlight' | 'checkbox' | 'edited_indicator';
 
 export class Node {
     constructor(nodeType: NodeType, sourcepos?: Position);

--- a/lib/node.js
+++ b/lib/node.js
@@ -18,6 +18,7 @@ function isContainer(node) {
         case "image":
         case "latex_inline":
         case "mention_highlight":
+        case "highlight_without_notification":
         case "search_highlight":
         case "custom_inline":
         case "custom_block":


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Added a new type of Node 'highlight_without_notification' which would be used for highlighting custom keywords with spaces

#### Ticket Link
n/a

